### PR TITLE
feat(ui): Add private routes to frontend & persist user sessions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^16.9.0",
     "react-helmet": "^5.2.1",
     "react-redux": "^7.2.1",
+    "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "webpack": "^4.39.2"

--- a/frontend/src/components/PrivateRoute.jsx
+++ b/frontend/src/components/PrivateRoute.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { navigate } from 'gatsby';
+import PropTypes from 'prop-types';
+
+// eslint-disable-next-line react/prop-types
+const PrivateRoute = ({ component: Component, auth, ...rest }) => {
+  if (!auth.isAuthenticated) {
+    navigate('/portal/login');
+    return null;
+  }
+
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <Component {...rest} />;
+};
+
+PrivateRoute.propTypes = {
+  auth: PropTypes.shape({
+    isAuthenticated: PropTypes.bool,
+    user: PropTypes.shape({
+      id: PropTypes.string,
+      name: PropTypes.string,
+    }),
+  }),
+};
+
+PrivateRoute.defaultProps = {
+  auth: {},
+};
+
+const mapStateToProps = (state) => ({
+  auth: state.auth,
+});
+
+export default connect(mapStateToProps)(PrivateRoute);

--- a/frontend/src/pages/dashboard.jsx
+++ b/frontend/src/pages/dashboard.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import store from '../redux/store';
+import { logoutBrother } from '../redux/actions/authActions';
+
+const Dashboard = () => {
+  const handleLogout = () => {
+    store.dispatch(logoutBrother());
+  };
+
+  return (
+    <div
+      className="container"
+      style={{
+        height: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <h1 className="text-center">This is a private page</h1>
+      <button
+        onClick={handleLogout}
+        type="button"
+        className="btn btn-warning ml-3"
+      >
+        Logout
+      </button>
+    </div>
+  );
+};
+
+Dashboard.propTypes = {
+  auth: PropTypes.shape({
+    isAuthenticated: PropTypes.bool,
+    user: PropTypes.shape({
+      id: PropTypes.string,
+      name: PropTypes.string,
+    }),
+  }),
+};
+
+Dashboard.defaultProps = {
+  auth: {},
+};
+
+const mapStateToProps = (state) => ({
+  auth: state.auth,
+});
+
+export default connect(mapStateToProps, {})(Dashboard);

--- a/frontend/src/pages/portal.jsx
+++ b/frontend/src/pages/portal.jsx
@@ -8,6 +8,13 @@ import store from '../redux/store';
 import Sample from './portal_pages/sample';
 import Register from './portal_pages/register';
 import Login from './portal_pages/login';
+import PrivateRoute from '../components/PrivateRoute';
+import Dashboard from './dashboard';
+
+import persistLogin from '../util/persist-login';
+
+// Checks localStorage for JWT and ensures authorized users can visit PrivateRoutes
+persistLogin();
 
 const Portal = () => {
   return (
@@ -17,6 +24,7 @@ const Portal = () => {
         <Sample exact path="/sample/:resultsAmount" />
         <Register exact path="/register" />
         <Login exact path="/login" />
+        <PrivateRoute exact path="/dashboard" component={Dashboard} />
       </Router>
     </Provider>
   );

--- a/frontend/src/pages/portal_pages/login.jsx
+++ b/frontend/src/pages/portal_pages/login.jsx
@@ -22,7 +22,7 @@ class Login extends Component {
       this.props.auth.isAuthenticated !== prevProps.auth.isAuthenticated &&
       this.props.auth.isAuthenticated
     ) {
-      navigate('/');
+      navigate('/portal/dashboard');
     }
     if (this.props.errors !== prevProps.errors && this.props.errors) {
       this.setState({ errors: this.props.errors });
@@ -52,50 +52,54 @@ class Login extends Component {
     return (
       <section className={loginStyles.root}>
         <div className="container">
-          <h1>
-            <b>Login</b> broski
-          </h1>
-          <form noValidate onSubmit={(event) => this.handleSubmit(event)}>
-            <div className="form-group">
-              <label htmlFor="email">Email</label>
-              <input
-                type="email"
-                id="email"
-                placeholder="Enter email"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.email}
-                error={errors.email}
-                className={classnames('form-control', {
-                  'is-invalid': errors.email || errors.emailnotfound,
-                })}
-              />
-              <span className="invalid-feedback">
-                {errors.email}
-                {errors.emailnotfound}
-              </span>
+          <div className="card">
+            <div className="card-body">
+              <h1>
+                <b>Login</b> broski
+              </h1>
+              <form noValidate onSubmit={(event) => this.handleSubmit(event)}>
+                <div className="form-group">
+                  <label htmlFor="email">Email</label>
+                  <input
+                    type="email"
+                    id="email"
+                    placeholder="Enter email"
+                    onChange={(event) => this.handleChange(event)}
+                    value={this.state.email}
+                    error={errors.email}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.email || errors.emailnotfound,
+                    })}
+                  />
+                  <span className="invalid-feedback">
+                    {errors.email}
+                    {errors.emailnotfound}
+                  </span>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="password">Password</label>
+                  <input
+                    type="password"
+                    id="password"
+                    placeholder="Enter password"
+                    onChange={(event) => this.handleChange(event)}
+                    value={this.state.password}
+                    error={errors.password}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.password || errors.passwordincorrect,
+                    })}
+                  />
+                  <span className="invalid-feedback">
+                    {errors.password}
+                    {errors.passwordincorrect}
+                  </span>
+                </div>
+                <button type="submit" className="btn btn-warning">
+                  Submit
+                </button>
+              </form>
             </div>
-            <div className="form-group">
-              <label htmlFor="password">Password</label>
-              <input
-                type="password"
-                id="password"
-                placeholder="Enter password"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.password}
-                error={errors.password}
-                className={classnames('form-control', {
-                  'is-invalid': errors.password || errors.passwordincorrect,
-                })}
-              />
-              <span className="invalid-feedback">
-                {errors.password}
-                {errors.passwordincorrect}
-              </span>
-            </div>
-            <button type="submit" className="btn btn-warning">
-              Submit
-            </button>
-          </form>
+          </div>
         </div>
       </section>
     );

--- a/frontend/src/pages/portal_pages/register.jsx
+++ b/frontend/src/pages/portal_pages/register.jsx
@@ -60,125 +60,116 @@ class Register extends Component {
     return (
       <section className={registerStyles.root}>
         <div className="container">
-          <h1>
-            <b>Register</b> a new brother
-          </h1>
-          <form noValidate onSubmit={(event) => this.handleSubmit(event)}>
-            <div className="form-group">
-              <label htmlFor="name">Name</label>
-              <input
-                type="text"
-                id="name"
-                placeholder="Enter name"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.name}
-                error={errors.name}
-                className={classnames('form-control', {
-                  'is-invalid': errors.name,
-                })}
-              />
-              <span className="invalid-feedback">{errors.name}</span>
+          <div className="card">
+            <div className="card-body">
+              <h1>
+                <b>Register</b> a new brother
+              </h1>
+              <form noValidate onSubmit={(event) => this.handleSubmit(event)}>
+                <div className="form-group">
+                  <label htmlFor="name">Name</label>
+                  <input
+                    type="text"
+                    id="name"
+                    placeholder="Enter name"
+                    onChange={(event) => this.handleChange(event)}
+                    value={this.state.name}
+                    error={errors.name}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.name,
+                    })}
+                  />
+                  <span className="invalid-feedback">{errors.name}</span>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="email">Email address</label>
+                  <input
+                    type="email"
+                    id="email"
+                    placeholder="Enter email"
+                    onChange={(event) => this.handleChange(event)}
+                    value={this.state.email}
+                    error={errors.email}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.email,
+                    })}
+                  />
+                  <span className="invalid-feedback">{errors.email}</span>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="major">Major</label>
+                  <select
+                    id="major"
+                    onChange={(event) => this.handleChange(event)}
+                    value={this.state.major}
+                    error={errors.major}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.major,
+                    })}
+                  >
+                    {Object.values(MajorEnum).map((major) => (
+                      <option key={major}>{major}</option>
+                    ))}
+                  </select>
+                  <span className="invalid-feedback">{errors.major}</span>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="name">Graduating year</label>
+                  <input
+                    type="number"
+                    id="graduatingYear"
+                    placeholder="Enter graduating year"
+                    onChange={(event) => this.handleChange(event)}
+                    value={this.state.graduatingYear}
+                    error={errors.graduatingYear}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.graduatingYear,
+                    })}
+                  />
+                  <span className="invalid-feedback">
+                    {errors.graduatingYear}
+                  </span>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="pledgeClass">Pledge class</label>
+                  <select
+                    id="pledgeClass"
+                    onChange={(event) => this.handleChange(event)}
+                    value={this.state.pledgeClass}
+                    error={errors.pledgeClass}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.pledgeClass,
+                    })}
+                  >
+                    {Object.values(PledgeClassEnum).map((pledgeClass) => (
+                      <option key={pledgeClass}>{pledgeClass}</option>
+                    ))}
+                  </select>
+                  <span className="invalid-feedback">{errors.pledgeClass}</span>
+                </div>
+                <div className="form-group">
+                  <label htmlFor="position">Position</label>
+                  <select
+                    id="position"
+                    onChange={(event) => this.handleChange(event)}
+                    value={this.state.position}
+                    error={errors.position}
+                    className={classnames('form-control', {
+                      'is-invalid': errors.position,
+                    })}
+                  >
+                    {Object.values(PositionEnum).map((position) => (
+                      <option key={position}>{position}</option>
+                    ))}
+                  </select>
+                  <span className="invalid-feedback">{errors.position}</span>
+                </div>
+                <button type="submit" className="btn btn-warning">
+                  Submit
+                </button>
+              </form>
             </div>
-            <div className="form-group">
-              <label htmlFor="email">Email address</label>
-              <input
-                type="email"
-                id="email"
-                placeholder="Enter email"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.email}
-                error={errors.email}
-                className={classnames('form-control', {
-                  'is-invalid': errors.email,
-                })}
-              />
-              <span className="invalid-feedback">{errors.email}</span>
-            </div>
-            <div className="form-group">
-              <label htmlFor="studentID">Student ID</label>
-              <input
-                type="number"
-                id="studentID"
-                placeholder="Enter Student ID (Numeric values only)"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.studentID}
-                error={errors.studentID}
-                className={classnames('form-control', {
-                  'is-invalid': errors.studentID,
-                })}
-              />
-              <span className="invalid-feedback">{errors.studentID}</span>
-            </div>
-            <div className="form-group">
-              <label htmlFor="major">Major</label>
-              <select
-                id="major"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.major}
-                error={errors.major}
-                className={classnames('form-control', {
-                  'is-invalid': errors.major,
-                })}
-              >
-                {Object.values(MajorEnum).map((major) => (
-                  <option key={major}>{major}</option>
-                ))}
-              </select>
-              <span className="invalid-feedback">{errors.major}</span>
-            </div>
-            <div className="form-group">
-              <label htmlFor="name">Graduating year</label>
-              <input
-                type="number"
-                id="graduatingYear"
-                placeholder="Enter graduating year"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.graduatingYear}
-                error={errors.graduatingYear}
-                className={classnames('form-control', {
-                  'is-invalid': errors.graduatingYear,
-                })}
-              />
-              <span className="invalid-feedback">{errors.graduatingYear}</span>
-            </div>
-            <div className="form-group">
-              <label htmlFor="pledgeClass">Pledge class</label>
-              <select
-                id="pledgeClass"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.pledgeClass}
-                error={errors.pledgeClass}
-                className={classnames('form-control', {
-                  'is-invalid': errors.pledgeClass,
-                })}
-              >
-                {Object.values(PledgeClassEnum).map((pledgeClass) => (
-                  <option key={pledgeClass}>{pledgeClass}</option>
-                ))}
-              </select>
-              <span className="invalid-feedback">{errors.pledgeClass}</span>
-            </div>
-            <div className="form-group">
-              <label htmlFor="position">Position</label>
-              <select
-                id="position"
-                onChange={(event) => this.handleChange(event)}
-                value={this.state.position}
-                error={errors.position}
-                className={classnames('form-control', {
-                  'is-invalid': errors.position,
-                })}
-              >
-                {Object.values(PositionEnum).map((position) => (
-                  <option key={position}>{position}</option>
-                ))}
-              </select>
-              <span className="invalid-feedback">{errors.position}</span>
-            </div>
-            <button type="submit" className="btn btn-warning">
-              Submit
-            </button>
-          </form>
+          </div>
         </div>
       </section>
     );

--- a/frontend/src/redux/actions/authActions.js
+++ b/frontend/src/redux/actions/authActions.js
@@ -5,7 +5,7 @@ import setAuthToken from '../../util/setAuthToken';
 import { GET_ERRORS, SET_CURRENT_BROTHER } from './types';
 
 // Helper function
-export const setCurrentUser = (decodedToken) => {
+export const setCurrentBrother = (decodedToken) => {
   return {
     type: SET_CURRENT_BROTHER,
     payload: decodedToken,
@@ -38,7 +38,7 @@ export const loginBrother = (brotherData) => (dispatch) => {
 
       // Decode token to get user data in payload, then store in redux state
       const decodedToken = jwtDecode(token);
-      dispatch(setCurrentUser(decodedToken));
+      dispatch(setCurrentBrother(decodedToken));
     })
     .catch((error) =>
       dispatch({ type: GET_ERRORS, payload: error.response.data })
@@ -50,5 +50,5 @@ export const logoutBrother = () => (dispatch) => {
   // Remove JWT from localStorage, auth header, and clear current logged-in brother
   localStorage.removeItem('authToken');
   setAuthToken(false);
-  dispatch(setCurrentUser({}));
+  dispatch(setCurrentBrother({}));
 };

--- a/frontend/src/util/persist-login.js
+++ b/frontend/src/util/persist-login.js
@@ -1,0 +1,28 @@
+// eslint-disable-next-line camelcase
+import jwt_decode from 'jwt-decode';
+import setAuthToken from './setAuthToken';
+import store from '../redux/store';
+import { setCurrentBrother, logoutBrother } from '../redux/actions/authActions';
+
+const persistLogin = () => {
+  // Checks for JSON Web Token in localStorage (should be refactored) to persist user logins
+  if (localStorage.authToken) {
+    const { authToken } = localStorage;
+
+    // Puts the token in authorization headers for all HTTP requests
+    setAuthToken(authToken);
+
+    // Decode the JSON Web Token (which is actually just a user object), and set it in global state
+    const decodedToken = jwt_decode(authToken);
+    store.dispatch(setCurrentBrother(decodedToken));
+
+    // Check if token is expired
+    const currentTime = Date.now() / 1000;
+    if (decodedToken.exp < currentTime) {
+      store.dispatch(logoutBrother());
+      window.location.href = './portal/login';
+    }
+  }
+};
+
+export default persistLogin;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
+    "gatsby-cli": "^2.12.99",
     "is-empty": "^1.2.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.10.3",


### PR DESCRIPTION
This change adds a `<PrivateRoute>` component that checks if users trying to visit the page are authenticated/authorized. If they are, the component is rendered, else they are redirected to the login page.

* Reference for `<PrivateRoute>`:
  * https://www.gatsbyjs.com/docs/client-only-routes-and-user-authentication/

This change also adds a `persist-login` function that is called in the `portal.jsx` file. This function checks if there is a JSON Web Token in `localStorage`, and sets it in the authorization headers for whenever HTTP requests are made. This function allows user sessions to persist.